### PR TITLE
fix: Add postgres group to datastore-statefulset.yaml

### DIFF
--- a/deploying/datastore/kubernetes/datastore-statefulset.yaml
+++ b/deploying/datastore/kubernetes/datastore-statefulset.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: antenna-postgres
     spec:
+      securityContext:
+        fsGroup: 70
       hostname: antenna-postgres
       containers:
         - name: antenna-postgres


### PR DESCRIPTION
Update the datastore-statefulset.yaml config file to include the postgres group (ID 70). This ensures that container processes run with the appropriate group permissions, preventing certificate-related permission issues.

Signed-off-by: Gergő Barta <gergo.ba@proton.me>