### PR TITLE
docs: Add cape-dev/verify-receiver session revoke missing entry

### DIFF
--- a/deploying/datastore/kubernetes/datastore-statefulset.yaml
+++ b/deploying/datastore/kubernetes/datastore-statefulset.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: antenna-postgres
     spec:
+      securityContext:
+        fsGroup: 70
       hostname: antenna-postgres
       containers:
         - name: antenna-postgres

--- a/recipes/caep-dev/verify-receiver/README.md
+++ b/recipes/caep-dev/verify-receiver/README.md
@@ -52,6 +52,22 @@ Follow the instructions in [Container Runtime Deployment](../../../deploying/rec
 
 3. Set the `content` property for this event type to `"@js/session_revoked.js"`.
 
+### Update the Receiver Deployment File
+
+1. Open `antenna-receiver/receiver-deployment.yaml`.
+2. Find the configMap with `name: receiver-action-handlers`
+3. Add a new element under the "items" entry for `session_revoked.js` as:
+   ```
+   - configMap:
+       name: receiver-action-handlers
+       items:
+         - key: log_event.js
+           path: js/log_event.js
+         - key: session_revoked.js     # Added for caep-dev verify-receiver scenario
+           path: js/session_revoked.js # Added for caep-dev verify-receiver scenario
+   ```
+Note: If the receiver and/or Config Maps have already been deployed, make sure to delete and recreate them to reflect the changes.
+
 ### Complete the Receiver Setup
 
 Follow the remaining instructions in the [Container Runtime Deployment](../../../deploying/receiver/container-runtime/README.md) guide to complete the receiver configuration and deployment.


### PR DESCRIPTION
This pull request updates the README to include missing configuration steps required when setting up the [caep-dev/verify-receiver](https://github.com/ibm-verify/verify-antenna-recipes/blob/main/recipes/caep-dev/verify-receiver/README.md) recipe on Kubernetes.

Currently, the antenna-receiver pod fails to start after deployment due to the `js/session_revoked.js` script not being present. The pull request adds instructions on how to include the missing entry for `js/session_revoked.js` in the `receiver-deployment.yaml` config file to resolve the issue.

Signed-off-by: Gergő Barta <gergo.ba@proton.me>